### PR TITLE
Chapter 28 Broadcast Intents

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.photogalery">
 
+    <permission
+        android:name="com.example.photogalery.PRIVATE"
+        android:protectionLevel="signature" />
+
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="com.example.photogalery.PRIVATE" />
 
     <application
         android:name=".PhotoGalleryApplication"
@@ -21,6 +26,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <receiver
+            android:name=".NotificationReceiver"
+            android:exported="false"
+            android:permission="com.example.photogalery.PRIVATE">
+            <intent-filter>
+                <action android:name="com.example.photogalery.SHOW_NOTIFICATION" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <permission
         android:name="com.example.photogalery.PRIVATE"
-        android:protectionLevel="normal" />
+        android:protectionLevel="signature" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="com.example.photogalery.PRIVATE" />
@@ -30,7 +30,7 @@
             android:name=".NotificationReceiver"
             android:exported="false"
             android:permission="com.example.photogalery.PRIVATE">
-            <intent-filter>
+            <intent-filter android:priority="-999">
                 <action android:name="com.example.photogalery.SHOW_NOTIFICATION" />
             </intent-filter>
         </receiver>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <permission
         android:name="com.example.photogalery.PRIVATE"
-        android:protectionLevel="signature" />
+        android:protectionLevel="normal" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="com.example.photogalery.PRIVATE" />

--- a/app/src/main/java/com/example/photogalery/NotificationReceiver.kt
+++ b/app/src/main/java/com/example/photogalery/NotificationReceiver.kt
@@ -1,0 +1,19 @@
+package com.example.photogalery
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+class NotificationReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent != null) {
+            Log.i(TAG, "received broadcast: ${intent.action}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "NotificationReceiver"
+    }
+}

--- a/app/src/main/java/com/example/photogalery/NotificationReceiver.kt
+++ b/app/src/main/java/com/example/photogalery/NotificationReceiver.kt
@@ -1,14 +1,33 @@
 package com.example.photogalery
 
+import android.app.Activity
+import android.app.Notification
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import androidx.core.app.NotificationManagerCompat
 
 class NotificationReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent) {
-        Log.i(TAG, "received broadcast: ${intent.action}")
+        Log.i(TAG, "received result: $resultCode")
+        if (resultCode != Activity.RESULT_OK) {
+            // A foreground activity canceled the broadcast
+            return
+        }
+
+        val requestCode = intent.getIntExtra(PollWorker.REQUEST_CODE, 0)
+        val notification: Notification? = intent.getParcelableExtra(PollWorker.NOTIFICATION)
+
+        val notificationManager: NotificationManagerCompat? = context?.let {
+            NotificationManagerCompat.from(
+                it
+            )
+        }
+        if (notification != null) {
+            notificationManager?.notify(requestCode, notification)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/example/photogalery/NotificationReceiver.kt
+++ b/app/src/main/java/com/example/photogalery/NotificationReceiver.kt
@@ -7,10 +7,8 @@ import android.util.Log
 
 class NotificationReceiver : BroadcastReceiver() {
 
-    override fun onReceive(context: Context?, intent: Intent?) {
-        if (intent != null) {
-            Log.i(TAG, "received broadcast: ${intent.action}")
-        }
+    override fun onReceive(context: Context?, intent: Intent) {
+        Log.i(TAG, "received broadcast: ${intent.action}")
     }
 
     companion object {

--- a/app/src/main/java/com/example/photogalery/PhotoGalleryFragment.kt
+++ b/app/src/main/java/com/example/photogalery/PhotoGalleryFragment.kt
@@ -4,27 +4,16 @@ import android.os.Bundle
 import android.util.Log
 import android.view.*
 import androidx.appcompat.widget.SearchView
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.work.*
 import java.util.concurrent.TimeUnit
 
-class PhotoGalleryFragment : VisibleFragment() {
+class PhotoGalleryFragment : PollNotificationHandlerFragment(R.layout.fragment_photo_gallery) {
 
     private lateinit var photoRecyclerView: RecyclerView
     private lateinit var photoGalleryViewModel: PhotoGalleryViewModel
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        val view=inflater.inflate(R.layout.fragment_photo_gallery, container, false)
-
-        return view
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -97,7 +86,7 @@ class PhotoGalleryFragment : VisibleFragment() {
             R.id.menu_item_toggle_polling -> {
                 val isPolling = QueryPreferences.isPolling(requireContext())
                 if (isPolling) {
-                    WorkManager.getInstance().cancelUniqueWork(POLL_WORK)
+                    context?.let { WorkManager.getInstance(it).cancelUniqueWork(POLL_WORK) }
                     QueryPreferences.setPolling(requireContext(), false)
                 } else {
                     val constraints = Constraints.Builder()
@@ -107,11 +96,13 @@ class PhotoGalleryFragment : VisibleFragment() {
                         .Builder(PollWorker::class.java, 15, TimeUnit.MINUTES)
                         .setConstraints(constraints)
                         .build()
-                    WorkManager.getInstance().enqueueUniquePeriodicWork(
-                        POLL_WORK,
-                        ExistingPeriodicWorkPolicy.KEEP,
-                        periodicRequest
-                    )
+                    context?.let {
+                        WorkManager.getInstance(it).enqueueUniquePeriodicWork(
+                            POLL_WORK,
+                            ExistingPeriodicWorkPolicy.KEEP,
+                            periodicRequest
+                        )
+                    }
                     QueryPreferences.setPolling(requireContext(), true)
                 }
                 activity?.invalidateOptionsMenu()

--- a/app/src/main/java/com/example/photogalery/PhotoGalleryFragment.kt
+++ b/app/src/main/java/com/example/photogalery/PhotoGalleryFragment.kt
@@ -2,10 +2,7 @@ package com.example.photogalery
 
 import android.os.Bundle
 import android.util.Log
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
-import android.view.View
+import android.view.*
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -14,10 +11,20 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.work.*
 import java.util.concurrent.TimeUnit
 
-class PhotoGalleryFragment : Fragment(R.layout.fragment_photo_gallery) {
+class PhotoGalleryFragment : VisibleFragment() {
 
     private lateinit var photoRecyclerView: RecyclerView
     private lateinit var photoGalleryViewModel: PhotoGalleryViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view=inflater.inflate(R.layout.fragment_photo_gallery, container, false)
+
+        return view
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/photogalery/PollNotificationHandlerFragment.kt
+++ b/app/src/main/java/com/example/photogalery/PollNotificationHandlerFragment.kt
@@ -7,9 +7,10 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.util.Log
 import android.widget.Toast
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 
-abstract class VisibleFragment : Fragment() {
+abstract class PollNotificationHandlerFragment(@LayoutRes val contentLayoutId: Int) : Fragment(contentLayoutId) {
 
     private val onShowNotification = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent) {

--- a/app/src/main/java/com/example/photogalery/PollWorker.kt
+++ b/app/src/main/java/com/example/photogalery/PollWorker.kt
@@ -1,5 +1,6 @@
 package com.example.photogalery
 
+import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -7,7 +8,6 @@ import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.example.photogalery.PhotoGalleryApplication.Companion.NOTIFICATION_CHANNEL_ID
@@ -61,18 +61,26 @@ class PollWorker(private val context: Context, workerParams: WorkerParameters) :
                 .setContentTitle(resources.getString(R.string.new_pictures_title))
                 .setContentText(resources.getString(R.string.new_pictures_text))
                 .setContentIntent(pendingIntent).setAutoCancel(true).build()
-            val notificationManager =
-                NotificationManagerCompat.from(context)
-            notificationManager.notify(0, notification)
 
-            context.sendBroadcast(Intent(ACTION_SHOW_NOTIFICATION), PERM_PRIVATE)
+            showBackgroundNotification(0, notification)
         }
         return Result.success()
+    }
+
+    private fun showBackgroundNotification(requestCode: Int, notification: Notification) {
+        val intent = Intent(ACTION_SHOW_NOTIFICATION).apply {
+            putExtra(REQUEST_CODE, requestCode)
+            putExtra(NOTIFICATION, notification)
+        }
+
+        context.sendOrderedBroadcast(intent, PERM_PRIVATE)
     }
 
     companion object {
         private const val TAG = "PollWorker"
         const val ACTION_SHOW_NOTIFICATION = "com.example.photogalery.SHOW_NOTIFICATION"
         const val PERM_PRIVATE = "com.example.photogalery.PRIVATE"
+        const val REQUEST_CODE = "REQUEST_CODE"
+        const val NOTIFICATION = "NOTIFICATION"
     }
 }

--- a/app/src/main/java/com/example/photogalery/PollWorker.kt
+++ b/app/src/main/java/com/example/photogalery/PollWorker.kt
@@ -2,6 +2,7 @@ package com.example.photogalery
 
 import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
@@ -48,10 +49,10 @@ class PollWorker(private val context: Context, workerParams: WorkerParameters) :
 
             val pendingIntent: PendingIntent? =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_MUTABLE)
-            } else {
-                PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_ONE_SHOT)
-            }
+                    PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_MUTABLE)
+                } else {
+                    PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_ONE_SHOT)
+                }
 
             val resources = context.resources
             val notification = NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
@@ -63,11 +64,15 @@ class PollWorker(private val context: Context, workerParams: WorkerParameters) :
             val notificationManager =
                 NotificationManagerCompat.from(context)
             notificationManager.notify(0, notification)
+
+            context.sendBroadcast(Intent(ACTION_SHOW_NOTIFICATION), PERM_PRIVATE)
         }
         return Result.success()
     }
 
     companion object {
         private const val TAG = "PollWorker"
+        const val ACTION_SHOW_NOTIFICATION = "com.example.photogalery.SHOW_NOTIFICATION"
+        const val PERM_PRIVATE = "com.example.photogalery.PRIVATE"
     }
 }

--- a/app/src/main/java/com/example/photogalery/VisibleFragment.kt
+++ b/app/src/main/java/com/example/photogalery/VisibleFragment.kt
@@ -1,0 +1,31 @@
+package com.example.photogalery
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+
+abstract class VisibleFragment : Fragment() {
+
+    private val onShowNotification = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent) {
+            Toast.makeText(requireContext(), "Got a broadcast: ${intent.action}", Toast.LENGTH_LONG)
+                .show()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val filter = IntentFilter(PollWorker.ACTION_SHOW_NOTIFICATION)
+        requireActivity().registerReceiver(
+            onShowNotification, filter, PollWorker.PERM_PRIVATE, null
+        )
+    }
+
+    override fun onStop() {
+        super.onStop()
+        requireActivity().unregisterReceiver(onShowNotification)
+    }
+}

--- a/app/src/main/java/com/example/photogalery/VisibleFragment.kt
+++ b/app/src/main/java/com/example/photogalery/VisibleFragment.kt
@@ -1,9 +1,11 @@
 package com.example.photogalery
 
+import android.app.Activity
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.util.Log
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 
@@ -13,6 +15,9 @@ abstract class VisibleFragment : Fragment() {
         override fun onReceive(context: Context?, intent: Intent) {
             Toast.makeText(requireContext(), "Got a broadcast: ${intent.action}", Toast.LENGTH_LONG)
                 .show()
+            //If we receive this, we're visib;le, so cancel the notification
+            Log.i(TAG, "canceling notification")
+            resultCode = Activity.RESULT_CANCELED
         }
     }
 
@@ -27,5 +32,9 @@ abstract class VisibleFragment : Fragment() {
     override fun onStop() {
         super.onStop()
         requireActivity().unregisterReceiver(onShowNotification)
+    }
+
+    companion object {
+        private const val TAG = "VisibleFragment"
     }
 }


### PR DESCRIPTION
## New features

- Prevent notification from appearing while the app is running using broadcasting

## Changes in code

- Sending ordered broadcast intents in PollWorker
- Creating a standalone broadcast receiver in NotificationReceiver class
- Adding receiver to the manifest
- Creating a dynamic receiver in VisibleFragment

## Screenshot(GIF) 
![Jun-27-2022 12-33-40](https://user-images.githubusercontent.com/102973575/175911884-765f4faa-d7f6-4c3f-b3c1-d64f39a2056c.gif)
